### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -1,5 +1,8 @@
 name: Build and Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/dganicolas/RutifyApi/security/code-scanning/1](https://github.com/dganicolas/RutifyApi/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs read operations (e.g., checking out the repository, caching dependencies, and running tests), we will set `contents: read` as the minimal required permission. This ensures that the workflow does not inadvertently gain unnecessary write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
